### PR TITLE
fix: Sample code passed wrong values to solve

### DIFF
--- a/solution.py
+++ b/solution.py
@@ -63,7 +63,7 @@ def search(values):
 
 if __name__ == '__main__':
     diag_sudoku_grid = '2.............62....1....7...6..8...3...9...7...6..4...4....8....52.............3'
-    display(solve(grid_values(diag_sudoku_grid)))
+    display(solve(diag_sudoku_grid))
 
     try:
         from visualize import visualize_assignments


### PR DESCRIPTION
The arguments passed to display in solution.py should match the
ones passed in solution_test.py. Specifically, fix to
pass the string representation to solve instead of the
dictionary. (Should have been fixed in an earlier commit,
but missed this line.)