### PR TITLE
Ignore redundant assignments in assign_value

### DIFF
--- a/solution.py
+++ b/solution.py
@@ -5,6 +5,11 @@ def assign_value(values, box, value):
     Please use this function to update your values dictionary!
     Assigns a value to a given box. If it updates the board record it.
     """
+
+    # Don't waste the time or memory appending actions that don't actually change any values
+    if values[box] == value:
+        return values
+
     values[box] = value
     if len(value) == 1:
         assignments.append(values.copy())

--- a/solution.py
+++ b/solution.py
@@ -6,7 +6,7 @@ def assign_value(values, box, value):
     Assigns a value to a given box. If it updates the board record it.
     """
 
-    # Don't waste the time or memory appending actions that don't actually change any values
+    # Don't waste memory appending actions that don't actually change any values
     if values[box] == value:
         return values
 


### PR DESCRIPTION
This is a small improvement suggested on the forums. It avoids storing a new copy of the dictionary for assignments that don't actually change anything.